### PR TITLE
feat: add HTTP request duration graphs, split dashboard into rows

### DIFF
--- a/maas-site-manager/maas_site_manager_stats.json
+++ b/maas-site-manager/maas_site_manager_stats.json
@@ -18,17 +18,27 @@
     "editable": true,
     "fiscalYearStartMonth": 0,
     "graphTooltip": 0,
-    "id": null,
     "links": [],
     "liveNow": false,
     "panels": [
+        {
+            "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 0
+            },
+            "id": 17,
+            "title": "API Logs",
+            "type": "row"
+        },
         {
             "datasource": "${lokids}",
             "gridPos": {
                 "h": 12,
                 "w": 24,
                 "x": 0,
-                "y": 0
+                "y": 1
             },
             "id": 8,
             "options": {
@@ -45,13 +55,437 @@
                 {
                     "datasource": "${lokids}",
                     "editorMode": "builder",
-                    "expr": "{pebble_service=\"msm\"} |= ``",
+                    "expr": "{pebble_service=\"msm\", juju_application=~\"$juju_application\", juju_model=~\"$juju_model\", juju_model_uuid=~\"$juju_model_uuid\", juju_unit=~\"$juju_unit\"} |= \"\"",
                     "queryType": "range",
                     "refId": "A"
                 }
             ],
             "title": "MAAS Site Manager API Logs",
             "type": "logs"
+        },
+        {
+            "collapsed": false,
+            "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 13
+            },
+            "id": 16,
+            "panels": [],
+            "title": "HTTP Request Metrics",
+            "type": "row"
+        },
+        {
+            "datasource": "${prometheusds}",
+            "description": "The amount of bytes sent per second in HTTP requests, per endpoint",
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "palette-classic"
+                    },
+                    "custom": {
+                        "axisCenteredZero": false,
+                        "axisColorMode": "text",
+                        "axisLabel": "",
+                        "axisPlacement": "auto",
+                        "barAlignment": 0,
+                        "drawStyle": "line",
+                        "fillOpacity": 0,
+                        "gradientMode": "none",
+                        "hideFrom": {
+                            "legend": false,
+                            "tooltip": false,
+                            "viz": false
+                        },
+                        "lineInterpolation": "linear",
+                        "lineWidth": 1,
+                        "pointSize": 5,
+                        "scaleDistribution": {
+                            "type": "linear"
+                        },
+                        "showPoints": "auto",
+                        "spanNulls": false,
+                        "stacking": {
+                            "group": "A",
+                            "mode": "none"
+                        },
+                        "thresholdsStyle": {
+                            "mode": "off"
+                        }
+                    },
+                    "mappings": [],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "green",
+                                "value": null
+                            },
+                            {
+                                "color": "red",
+                                "value": 80
+                            }
+                        ]
+                    },
+                    "unit": "Bps"
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 14,
+                "w": 8,
+                "x": 0,
+                "y": 14
+            },
+            "id": 14,
+            "options": {
+                "legend": {
+                    "calcs": [],
+                    "displayMode": "list",
+                    "placement": "bottom",
+                    "showLegend": true
+                },
+                "tooltip": {
+                    "mode": "single",
+                    "sort": "none"
+                }
+            },
+            "targets": [
+                {
+                    "datasource": "${prometheusds}",
+                    "editorMode": "builder",
+                    "expr": "rate(http_request_size_bytes_sum[5m])",
+                    "legendFormat": "{{handler}}",
+                    "range": true,
+                    "refId": "A"
+                }
+            ],
+            "title": "HTTP Request Bytes per Second",
+            "type": "timeseries"
+        },
+        {
+            "datasource": "${prometheusds}",
+            "description": "A 5 minute running average of the time spent per HTTP request, for each endpoint/method",
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "palette-classic"
+                    },
+                    "custom": {
+                        "axisCenteredZero": false,
+                        "axisColorMode": "text",
+                        "axisLabel": "",
+                        "axisPlacement": "auto",
+                        "barAlignment": 0,
+                        "drawStyle": "line",
+                        "fillOpacity": 0,
+                        "gradientMode": "none",
+                        "hideFrom": {
+                            "legend": false,
+                            "tooltip": false,
+                            "viz": false
+                        },
+                        "lineInterpolation": "linear",
+                        "lineWidth": 1,
+                        "pointSize": 5,
+                        "scaleDistribution": {
+                            "type": "linear"
+                        },
+                        "showPoints": "auto",
+                        "spanNulls": false,
+                        "stacking": {
+                            "group": "A",
+                            "mode": "none"
+                        },
+                        "thresholdsStyle": {
+                            "mode": "off"
+                        }
+                    },
+                    "mappings": [],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "green",
+                                "value": null
+                            },
+                            {
+                                "color": "red",
+                                "value": 80
+                            }
+                        ]
+                    },
+                    "unit": "s"
+                },
+                "overrides": [
+                    {
+                        "matcher": {
+                            "id": "byRegexp",
+                            "options": "/((raw) .*)|(.*none)/"
+                        },
+                        "properties": [
+                            {
+                                "id": "custom.hideFrom",
+                                "value": {
+                                    "legend": true,
+                                    "tooltip": true,
+                                    "viz": true
+                                }
+                            }
+                        ]
+                    }
+                ]
+            },
+            "gridPos": {
+                "h": 14,
+                "w": 8,
+                "x": 8,
+                "y": 14
+            },
+            "id": 12,
+            "options": {
+                "legend": {
+                    "calcs": [],
+                    "displayMode": "list",
+                    "placement": "bottom",
+                    "showLegend": true
+                },
+                "tooltip": {
+                    "mode": "single",
+                    "sort": "none"
+                }
+            },
+            "targets": [
+                {
+                    "datasource": "${prometheusds}",
+                    "editorMode": "builder",
+                    "expr": "sum by(handler, method) (rate(http_request_duration_seconds_sum[5m]))",
+                    "legendFormat": "raw {{handler}} ({{method}}",
+                    "range": true,
+                    "refId": "A"
+                },
+                {
+                    "datasource": "${prometheusds}",
+                    "editorMode": "builder",
+                    "expr": "sum by(handler, method) (rate(http_request_duration_seconds_count[5m]))",
+                    "hide": false,
+                    "legendFormat": "raw {{handler}} ({{method}}) count",
+                    "range": true,
+                    "refId": "B"
+                },
+                {
+                    "datasource": {
+                        "name": "Expression",
+                        "type": "__expr__",
+                        "uid": "__expr__"
+                    },
+                    "expression": "$A / $B",
+                    "hide": false,
+                    "refId": "endpoint",
+                    "type": "math"
+                }
+            ],
+            "title": "HTTP Request Duration per Endpoint, Method (5 min running avg)",
+            "type": "timeseries"
+        },
+        {
+            "datasource": "${prometheusds}",
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "palette-classic"
+                    },
+                    "custom": {
+                        "axisCenteredZero": false,
+                        "axisColorMode": "text",
+                        "axisLabel": "",
+                        "axisPlacement": "auto",
+                        "barAlignment": 0,
+                        "drawStyle": "line",
+                        "fillOpacity": 0,
+                        "gradientMode": "none",
+                        "hideFrom": {
+                            "legend": false,
+                            "tooltip": false,
+                            "viz": false
+                        },
+                        "lineInterpolation": "linear",
+                        "lineWidth": 1,
+                        "pointSize": 5,
+                        "scaleDistribution": {
+                            "type": "linear"
+                        },
+                        "showPoints": "auto",
+                        "spanNulls": false,
+                        "stacking": {
+                            "group": "A",
+                            "mode": "none"
+                        },
+                        "thresholdsStyle": {
+                            "mode": "off"
+                        }
+                    },
+                    "mappings": [],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "green",
+                                "value": null
+                            },
+                            {
+                                "color": "red",
+                                "value": 80
+                            }
+                        ]
+                    }
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 14,
+                "w": 8,
+                "x": 16,
+                "y": 14
+            },
+            "id": 13,
+            "options": {
+                "legend": {
+                    "calcs": [],
+                    "displayMode": "list",
+                    "placement": "bottom",
+                    "showLegend": true
+                },
+                "tooltip": {
+                    "mode": "single",
+                    "sort": "none"
+                }
+            },
+            "targets": [
+                {
+                    "datasource": "${prometheusds}",
+                    "editorMode": "builder",
+                    "expr": "rate(http_requests_total[5m])",
+                    "legendFormat": "{{handler}} ({{method}})",
+                    "range": true,
+                    "refId": "A"
+                }
+            ],
+            "title": "HTTP Requests per Second",
+            "type": "timeseries"
+        },
+        {
+            "datasource": "${prometheusds}",
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "thresholds"
+                    },
+                    "custom": {
+                        "fillOpacity": 70,
+                        "lineWidth": 1
+                    },
+                    "mappings": [],
+                    "thresholds": {
+                        "mode": "percentage",
+                        "steps": [
+                            {
+                                "color": "green",
+                                "value": null
+                            },
+                            {
+                                "color": "yellow",
+                                "value": 75
+                            },
+                            {
+                                "color": "orange",
+                                "value": 85
+                            },
+                            {
+                                "color": "red",
+                                "value": 95
+                            }
+                        ]
+                    },
+                    "unit": "s"
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 15,
+                "w": 24,
+                "x": 0,
+                "y": 28
+            },
+            "id": 11,
+            "interval": "2m",
+            "options": {
+                "colWidth": 0.9,
+                "legend": {
+                    "displayMode": "list",
+                    "placement": "bottom",
+                    "showLegend": true
+                },
+                "rowHeight": 0.9,
+                "showValue": "auto",
+                "tooltip": {
+                    "mode": "single",
+                    "sort": "none"
+                }
+            },
+            "targets": [
+                {
+                    "datasource": "${prometheusds}",
+                    "editorMode": "builder",
+                    "expr": "histogram_quantile(0.99, sum by(le) (rate(http_request_duration_highr_seconds_bucket[5m])))",
+                    "legendFormat": "99th percentile",
+                    "range": true,
+                    "refId": "A"
+                },
+                {
+                    "datasource": "${prometheusds}",
+                    "editorMode": "builder",
+                    "expr": "histogram_quantile(0.95, sum by(le) (rate(http_request_duration_highr_seconds_bucket[5m])))",
+                    "hide": false,
+                    "legendFormat": "95th percentile",
+                    "range": true,
+                    "refId": "B"
+                },
+                {
+                    "datasource": "${prometheusds}",
+                    "editorMode": "builder",
+                    "expr": "histogram_quantile(0.9, sum by(le) (rate(http_request_duration_highr_seconds_bucket[5m])))",
+                    "hide": false,
+                    "legendFormat": "90th percentile",
+                    "range": true,
+                    "refId": "C"
+                },
+                {
+                    "datasource": "${prometheusds}",
+                    "editorMode": "builder",
+                    "expr": "histogram_quantile(0.75, sum by(le) (rate(http_request_duration_highr_seconds_bucket[5m])))",
+                    "hide": false,
+                    "legendFormat": "75th percentile",
+                    "range": true,
+                    "refId": "D"
+                }
+            ],
+            "title": "Percentile of HTTP Request Duration (5 min average)",
+            "type": "status-history"
+        },
+        {
+            "collapsed": false,
+            "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 43
+            },
+            "id": 15,
+            "panels": [],
+            "title": "Database Query Metrics",
+            "type": "row"
         },
         {
             "datasource": "${prometheusds}",
@@ -126,7 +560,7 @@
                 "h": 14,
                 "w": 12,
                 "x": 0,
-                "y": 12
+                "y": 44
             },
             "id": 6,
             "options": {
@@ -145,7 +579,7 @@
                 {
                     "datasource": "${prometheusds}",
                     "editorMode": "builder",
-                    "expr": "sum by(handler, method) (rate(db_queries_duration_seconds_sum[5m]))",
+                    "expr": "sum by(handler, method) (rate(db_queries_duration_seconds_sum{juju_application=~\"$juju_application\",juju_model=~\"$juju_model\",juju_model_uuid=~\"$juju_model_uuid\",juju_unit=~\"$juju_unit\"}[5m]))",
                     "legendFormat": "raw {{handler}} ({{method}})",
                     "range": true,
                     "refId": "A"
@@ -153,7 +587,7 @@
                 {
                     "datasource": "${prometheusds}",
                     "editorMode": "builder",
-                    "expr": "sum by(handler, method) (rate(db_queries_duration_seconds_count[5m]))",
+                    "expr": "sum by(handler, method) (rate(db_queries_duration_seconds_count{juju_application=~\"$juju_application\",juju_model=~\"$juju_model\",juju_model_uuid=~\"$juju_model_uuid\",juju_unit=~\"$juju_unit\"}[5m]))",
                     "hide": false,
                     "legendFormat": "raw {{handler}} count ({{method}})",
                     "range": true,
@@ -171,7 +605,7 @@
                     "type": "math"
                 }
             ],
-            "title": "DB Query Time per endpoint, method (5 min running avg)",
+            "title": "DB Query Time per Endpoint, Method (5 min running avg)",
             "type": "timeseries"
         },
         {
@@ -234,7 +668,7 @@
                 "h": 14,
                 "w": 12,
                 "x": 12,
-                "y": 12
+                "y": 44
             },
             "id": 10,
             "options": {
@@ -253,7 +687,7 @@
                 {
                     "datasource": "${prometheusds}",
                     "editorMode": "builder",
-                    "expr": "sum by(handler, method) (rate(db_queries_total{handler!=\"none\"}[5m]))",
+                    "expr": "sum by(handler, method) (rate(db_queries_total{handler!=\"none\",juju_application=~\"$juju_application\",juju_model=~\"$juju_model\",juju_model_uuid=~\"$juju_model_uuid\",juju_unit=~\"$juju_unit\"}[5m]))",
                     "legendFormat": "{{handler}} ({{method}})",
                     "range": true,
                     "refId": "A"
@@ -304,7 +738,7 @@
                 "h": 15,
                 "w": 24,
                 "x": 0,
-                "y": 26
+                "y": 58
             },
             "id": 9,
             "interval": "2.5m",
@@ -327,7 +761,7 @@
                 {
                     "datasource": "${prometheusds}",
                     "editorMode": "builder",
-                    "expr": "histogram_quantile(0.99, sum by(le) (rate(db_queries_duration_seconds_bucket{handler!=\"none\"}[5m])))",
+                    "expr": "histogram_quantile(0.99, sum by(le) (rate(db_queries_duration_seconds_bucket{handler!=\"none\",juju_application=~\"$juju_application\",juju_model=~\"$juju_model\",juju_model_uuid=~\"$juju_model_uuid\",juju_unit=~\"$juju_unit\"}[5m])))",
                     "format": "time_series",
                     "hide": false,
                     "legendFormat": "99th percentile",
@@ -337,7 +771,7 @@
                 {
                     "datasource": "${prometheusds}",
                     "editorMode": "builder",
-                    "expr": "histogram_quantile(0.95, sum by(le) (rate(db_queries_duration_seconds_bucket{handler!=\"none\"}[5m])))",
+                    "expr": "histogram_quantile(0.95, sum by(le) (rate(db_queries_duration_seconds_bucket{handler!=\"none\",juju_application=~\"$juju_application\",juju_model=~\"$juju_model\",juju_model_uuid=~\"$juju_model_uuid\",juju_unit=~\"$juju_unit\"}[5m])))",
                     "format": "time_series",
                     "hide": false,
                     "legendFormat": "95th percentile",
@@ -347,7 +781,7 @@
                 {
                     "datasource": "${prometheusds}",
                     "editorMode": "builder",
-                    "expr": "histogram_quantile(0.9, sum by(le) (rate(db_queries_duration_seconds_bucket{handler!=\"none\"}[5m])))",
+                    "expr": "histogram_quantile(0.9, sum by(le) (rate(db_queries_duration_seconds_bucket{handler!=\"none\",juju_application=~\"$juju_application\",juju_model=~\"$juju_model\",juju_model_uuid=~\"$juju_model_uuid\",juju_unit=~\"$juju_unit\"}[5m])))",
                     "format": "time_series",
                     "hide": false,
                     "legendFormat": "90th percentile",
@@ -357,7 +791,7 @@
                 {
                     "datasource": "${prometheusds}",
                     "editorMode": "builder",
-                    "expr": "histogram_quantile(0.75, sum by(le) (rate(db_queries_duration_seconds_bucket{handler!=\"none\"}[5m])))",
+                    "expr": "histogram_quantile(0.75, sum by(le) (rate(db_queries_duration_seconds_bucket{handler!=\"none\",juju_application=~\"$juju_application\",juju_model=~\"$juju_model\",juju_model_uuid=~\"$juju_model_uuid\",juju_unit=~\"$juju_unit\"}[5m])))",
                     "format": "time_series",
                     "hide": false,
                     "legendFormat": "75th percentile",
@@ -374,7 +808,168 @@
     "style": "dark",
     "tags": [],
     "templating": {
-        "list": []
+        "list": [
+            {
+                "current": {
+                    "selected": false,
+                    "text": "All",
+                    "value": "$__all"
+                },
+                "hide": 0,
+                "includeAll": true,
+                "label": "Loki datasource",
+                "multi": true,
+                "name": "lokids",
+                "options": [],
+                "query": "loki",
+                "refresh": 1,
+                "regex": "",
+                "skipUrlSync": false,
+                "type": "datasource"
+            },
+            {
+                "current": {
+                    "selected": false,
+                    "text": "All",
+                    "value": "$__all"
+                },
+                "hide": 0,
+                "includeAll": true,
+                "label": "Prometheus datasource",
+                "multi": true,
+                "name": "prometheusds",
+                "options": [],
+                "query": "prometheus",
+                "refresh": 1,
+                "regex": "",
+                "skipUrlSync": false,
+                "type": "datasource"
+            },
+            {
+                "allValue": ".*",
+                "current": {
+                    "selected": false,
+                    "text": "All",
+                    "value": "$__all"
+                },
+                "datasource": {
+                    "uid": "${prometheusds}"
+                },
+                "definition": "label_values(up{juju_model=~\"$juju_model\",juju_model_uuid=~\"$juju_model_uuid\",juju_application=~\"$juju_application\"},juju_unit)",
+                "hide": 0,
+                "includeAll": true,
+                "label": "Juju unit",
+                "multi": true,
+                "name": "juju_unit",
+                "options": [],
+                "query": {
+                    "query": "label_values(up{juju_model=~\"$juju_model\",juju_model_uuid=~\"$juju_model_uuid\",juju_application=~\"$juju_application\"},juju_unit)",
+                    "refId": "StandardVariableQuery"
+                },
+                "refresh": 1,
+                "regex": "",
+                "skipUrlSync": false,
+                "sort": 0,
+                "tagValuesQuery": "",
+                "tags": [],
+                "tagsQuery": "",
+                "type": "query",
+                "useTags": false
+            },
+            {
+                "allValue": ".*",
+                "current": {
+                    "selected": false,
+                    "text": "All",
+                    "value": "$__all"
+                },
+                "datasource": {
+                    "uid": "${prometheusds}"
+                },
+                "definition": "label_values(up{juju_model=~\"$juju_model\",juju_model_uuid=~\"$juju_model_uuid\"},juju_application)",
+                "hide": 0,
+                "includeAll": true,
+                "label": "Juju application",
+                "multi": true,
+                "name": "juju_application",
+                "options": [],
+                "query": {
+                    "query": "label_values(up{juju_model=~\"$juju_model\",juju_model_uuid=~\"$juju_model_uuid\"},juju_application)",
+                    "refId": "StandardVariableQuery"
+                },
+                "refresh": 1,
+                "regex": "",
+                "skipUrlSync": false,
+                "sort": 0,
+                "tagValuesQuery": "",
+                "tags": [],
+                "tagsQuery": "",
+                "type": "query",
+                "useTags": false
+            },
+            {
+                "allValue": ".*",
+                "current": {
+                    "selected": false,
+                    "text": "All",
+                    "value": "$__all"
+                },
+                "datasource": {
+                    "uid": "${prometheusds}"
+                },
+                "definition": "label_values(up{juju_model=~\"$juju_model\"},juju_model_uuid)",
+                "hide": 0,
+                "includeAll": true,
+                "label": "Juju model uuid",
+                "multi": true,
+                "name": "juju_model_uuid",
+                "options": [],
+                "query": {
+                    "query": "label_values(up{juju_model=~\"$juju_model\"},juju_model_uuid)",
+                    "refId": "StandardVariableQuery"
+                },
+                "refresh": 1,
+                "regex": "",
+                "skipUrlSync": false,
+                "sort": 0,
+                "tagValuesQuery": "",
+                "tags": [],
+                "tagsQuery": "",
+                "type": "query",
+                "useTags": false
+            },
+            {
+                "allValue": ".*",
+                "current": {
+                    "selected": false,
+                    "text": "All",
+                    "value": "$__all"
+                },
+                "datasource": {
+                    "uid": "${prometheusds}"
+                },
+                "definition": "label_values(up,juju_model)",
+                "hide": 0,
+                "includeAll": true,
+                "label": "Juju model",
+                "multi": true,
+                "name": "juju_model",
+                "options": [],
+                "query": {
+                    "query": "label_values(up,juju_model)",
+                    "refId": "StandardVariableQuery"
+                },
+                "refresh": 1,
+                "regex": "",
+                "skipUrlSync": false,
+                "sort": 0,
+                "tagValuesQuery": "",
+                "tags": [],
+                "tagsQuery": "",
+                "type": "query",
+                "useTags": false
+            }
+        ]
     },
     "time": {
         "from": "now-1h",
@@ -384,6 +979,6 @@
     "timezone": "",
     "title": "MAAS Site Manager Dashboard",
     "uid": "fc1a4d5d-dfa5-41f9-ab2b-34b5ecaf735d",
-    "version": 14,
+    "version": 1,
     "weekStart": ""
 }


### PR DESCRIPTION
This adds new charts for HTTP request metrics, as well as organizes the dashboard into rows

![new_msm_logs](https://github.com/user-attachments/assets/62e7386e-d306-4fe6-b590-d53111312519)
![new_msm_http](https://github.com/user-attachments/assets/9fc594e6-c67b-40a4-b6de-530047dbddc9)
![new_msm_queries](https://github.com/user-attachments/assets/a42db1cc-4bcd-4077-a657-7dfc5df480fc)

