### PR TITLE
chore: remove ipv6 subnet threshold

### DIFF
--- a/maas/maas_stats.json
+++ b/maas/maas_stats.json
@@ -1823,10 +1823,6 @@
               {
                 "color": "green",
                 "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
               }
             ]
           }


### PR DESCRIPTION
Stops ipv6 subnets going red unnecessarily after weekly meeting discussion.